### PR TITLE
Change JacobiWeight Conversion

### DIFF
--- a/src/JacobiWeightOperators.jl
+++ b/src/JacobiWeightOperators.jl
@@ -306,7 +306,7 @@ function defaultConversion(A::JacobiWeight{<:Any,<:IntervalOrSegmentDomain},B::J
     if isapprox(A.β,B.β) && isapprox(A.α,B.α)
         ConversionWrapper(SpaceOperator(Conversion(A.space,B.space),A,B))
     elseif isapprox(A.β-B.β, A.space.b-B.space.b) && isapprox(A.α-B.α, A.space.a-B.space.a)
-        Multiplication(jacobiweight(A.β-B.β,A.α-B.α,domain(A)),A.space)
+        ConversionWrapper(SpaceOperator(Multiplication(jacobiweight(A.β-B.β,A.α-B.α,domain(A)),A.space),A,B))
     else
         C=JacobiWeight(A.β,A.α,Jacobi(B.space.b+A.β-B.β,B.space.a+A.α-B.α))
         ConversionWrapper(Conversion(A,C)*Conversion(C,B))

--- a/src/JacobiWeightOperators.jl
+++ b/src/JacobiWeightOperators.jl
@@ -330,7 +330,16 @@ defaultConversion(A::JacobiWeight{<:Any,<:IntervalOrSegmentDomain},B::Space{<:In
         Conversion(A,JacobiWeight(0,0,B)),
         A,B))
 
-
+function defaultConversion(A::JacobiWeight{<:Any,<:IntervalOrSegmentDomain},B::JacobiWeight{<:Any,<:IntervalOrSegmentDomain})
+    if isapprox(A.β,B.β) && isapprox(A.α,B.α)
+        ConversionWrapper(SpaceOperator(Conversion(A.space,B.space),A,B))
+    elseif isapprox(A.β-B.β, A.space.B-B.space.B) && isapprox(A.α-B.α, A.space.a-B.space.a)
+        Multiplication(jacobiweight(A.β-B.β,A.α-B.α,domain(A)))
+    else
+        C=JacobiWeight(A.β,A.α,Jacobi(B.space.b+A.β-B.β,B.space.a+A.α-B.α))
+        ConversionWrapper(Conversion(A,C)*Conversion(C,B))
+    end
+end
 
 
 

--- a/src/JacobiWeightOperators.jl
+++ b/src/JacobiWeightOperators.jl
@@ -306,7 +306,7 @@ function defaultConversion(A::JacobiWeight{<:Any,<:IntervalOrSegmentDomain},B::J
     if isapprox(A.β,B.β) && isapprox(A.α,B.α)
         ConversionWrapper(SpaceOperator(Conversion(A.space,B.space),A,B))
     elseif isapprox(A.β-B.β, A.space.B-B.space.B) && isapprox(A.α-B.α, A.space.a-B.space.a)
-        Multiplication(jacobiweight(A.β-B.β,A.α-B.α,domain(A)))
+        Multiplication(jacobiweight(A.β-B.β,A.α-B.α,domain(A)),A.space)
     else
         C=JacobiWeight(A.β,A.α,Jacobi(B.space.b+A.β-B.β,B.space.a+A.α-B.α))
         ConversionWrapper(Conversion(A,C)*Conversion(C,B))

--- a/src/JacobiWeightOperators.jl
+++ b/src/JacobiWeightOperators.jl
@@ -308,7 +308,7 @@ function defaultConversion(A::JacobiWeight{<:Any,<:IntervalOrSegmentDomain},B::J
     elseif isapprox(A.β-B.β, A.space.b-B.space.b) && isapprox(A.α-B.α, A.space.a-B.space.a)
         ConversionWrapper(SpaceOperator(Multiplication(jacobiweight(A.β-B.β,A.α-B.α,domain(A)),A.space),A,B))
     else
-        C=JacobiWeight(A.β,A.α,Jacobi(B.space.b+A.β-B.β,B.space.a+A.α-B.α))
+        C=JacobiWeight(A.β,A.α,Jacobi(B.space.b+A.β-B.β,B.space.a+A.α-B.α,domain(A)))
         ConversionWrapper(Conversion(C,B)*Conversion(A,C))
     end
 end

--- a/src/JacobiWeightOperators.jl
+++ b/src/JacobiWeightOperators.jl
@@ -305,7 +305,7 @@ defaultConversion(A::JacobiWeight{<:Any,<:IntervalOrSegmentDomain},B::Space{<:In
 function defaultConversion(A::JacobiWeight{<:Any,<:IntervalOrSegmentDomain},B::JacobiWeight{<:Any,<:IntervalOrSegmentDomain})
     if isapprox(A.β,B.β) && isapprox(A.α,B.α)
         ConversionWrapper(SpaceOperator(Conversion(A.space,B.space),A,B))
-    elseif isapprox(A.β-B.β, A.space.B-B.space.B) && isapprox(A.α-B.α, A.space.a-B.space.a)
+    elseif isapprox(A.β-B.β, A.space.b-B.space.b) && isapprox(A.α-B.α, A.space.a-B.space.a)
         Multiplication(jacobiweight(A.β-B.β,A.α-B.α,domain(A)),A.space)
     else
         C=JacobiWeight(A.β,A.α,Jacobi(B.space.b+A.β-B.β,B.space.a+A.α-B.α))

--- a/src/JacobiWeightOperators.jl
+++ b/src/JacobiWeightOperators.jl
@@ -292,34 +292,6 @@ conversion_rule(A::JacobiWeight,B::Space{D}) where {D<:IntervalOrSegmentDomain} 
 
 
 # override defaultConversion instead of Conversion to avoid ambiguity errors
-function defaultConversion(A::JacobiWeight{<:Any,<:IntervalOrSegmentDomain},B::JacobiWeight{<:Any,<:IntervalOrSegmentDomain})
-    @assert isapproxinteger(A.β-B.β) && isapproxinteger(A.α-B.α)
-
-    if isapprox(A.β,B.β) && isapprox(A.α,B.α)
-        ConversionWrapper(SpaceOperator(Conversion(A.space,B.space),A,B))
-    else
-        @assert A.β≥B.β&&A.α≥B.α
-        # first check if a multiplication by JacobiWeight times B.space is overloaded
-        # this is currently designed for Jacobi multiplied by (1-x), etc.
-        βdif,αdif=round(Int,A.β-B.β),round(Int,A.α-B.α)
-        d=domain(A)
-        M=Multiplication(jacobiweight(βdif,αdif,d),
-                         A.space)
-
-        if rangespace(M)==JacobiWeight(βdif,αdif,A.space)
-            # M is the default, so we should use multiplication by polynomials instead
-            x=Fun(identity,d)
-            y=mobius(d,x)   # we use mobius instead of tocanonical so that it works for Funs
-            m=(1+y)^βdif*(1-y)^αdif
-            MC=promoterangespace(Multiplication(m,A.space),B.space)
-
-            ConversionWrapper(SpaceOperator(MC,A,B))# Wrap the operator with the correct spaces
-        else
-            ConversionWrapper(SpaceOperator(promoterangespace(M,B.space),
-                                            A,B))
-        end
-    end
-end
 
 defaultConversion(A::Space{<:IntervalOrSegmentDomain,<:Real},B::JacobiWeight{<:Any,<:IntervalOrSegmentDomain}) =
     ConversionWrapper(SpaceOperator(

--- a/src/JacobiWeightOperators.jl
+++ b/src/JacobiWeightOperators.jl
@@ -309,7 +309,7 @@ function defaultConversion(A::JacobiWeight{<:Any,<:IntervalOrSegmentDomain},B::J
         ConversionWrapper(SpaceOperator(Multiplication(jacobiweight(A.β-B.β,A.α-B.α,domain(A)),A.space),A,B))
     else
         C=JacobiWeight(A.β,A.α,Jacobi(B.space.b+A.β-B.β,B.space.a+A.α-B.α))
-        ConversionWrapper(Conversion(A,C)*Conversion(C,B))
+        ConversionWrapper(Conversion(C,B)*Conversion(A,C))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -128,6 +128,8 @@ end
         C=Conversion(S1,S2)
         Cf=C*f
         @test Cf(0.1) ≈ f(0.1)
+    
+        @test Conversion(JacobiWeight(2,0,Jacobi(2,-2)),Legendre()) == Conversion(JacobiWeight(2,0,Jacobi(2,-2)),JacobiWeight(2,0,Jacobi(2,0)),Legendre())
     end
 
     @testset "Array Conversion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,6 +130,7 @@ end
         @test Cf(0.1) ≈ f(0.1)
     
         C=Conversion(JacobiWeight(2,0,Jacobi(2,-2)),Legendre())
+        println(C)
         @test Matrix(C[1:2,1:2]) = [4/3 -2;2 -2.4]
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,7 +129,8 @@ end
         Cf=C*f
         @test Cf(0.1) ≈ f(0.1)
     
-        @test Conversion(JacobiWeight(2,0,Jacobi(2,-2)),Legendre()) == Conversion(JacobiWeight(2,0,Jacobi(2,-2)),JacobiWeight(2,0,Jacobi(2,0)),Legendre())
+        C=Conversion(JacobiWeight(2,0,Jacobi(2,-2)),Legendre())
+        @test Matrix(C[1:2,1:2]) = [4/3 -2;2 -2.4]
     end
 
     @testset "Array Conversion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,8 +130,7 @@ end
         @test Cf(0.1) ≈ f(0.1)
     
         C=Conversion(JacobiWeight(2,0,Jacobi(2,-2)),Legendre())
-        println(C)
-        @test Matrix(C[1:2,1:2]) = [4/3 -2;2 -2.4]
+        @test C[1,1]==4/3 && C[1,2]==-2 && C[2,1]==2 && C[2,2]==-2.4
     end
 
     @testset "Array Conversion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,7 +147,7 @@ end
 
         f = Fun(a, rand(10))
         @test f(0.1) ≈ (C*f)(0.1)
-    end
+    end 
 
     @testset "Equivalent spaces" begin
         @test norm(Fun(cos,Chebyshev)-Fun(cos,Jacobi(-0.5,-0.5)))<100eps()


### PR DESCRIPTION
Changed the routine of the conversion. Not sure if it works as I rewrote all codes.

`A=JacobiWeight(2,0,Jacobi(2,-2))`
`B=Legendre()`

Before change:
`Conversion(A,B)=Conversion(A,JacobiWeight(0,0,Jacobi(0,-2)),B)`
where `Conversion(JacobiWeight(0,0,Jacobi(0,-2)),Legendre())` is not well-defined (has some `NaN`s)

After change:
`Conversion(A,B)=Conversion(A,JacobiWeight(2,0,Jacobi(2,0)),B)`

The example has been added to test.