### PR TITLE
don't test for undef exports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunSingularities"
 uuid = "f8fcb915-6b99-5be2-b79a-d6dbef8e6e7e"
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ using Test
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(ApproxFunSingularities, ambiguities=false)
+    Aqua.test_all(ApproxFunSingularities, ambiguities=false, undefined_exports=false)
 end
 
 @testset "Sqrt" begin


### PR DESCRIPTION
Tests for undefined exports require `ApproxFunBase` v0.7. The next version will drop support for older versions of `ApproxFunBase`, at which point the test may be reintroduced.