### PR TITLE
Ignore ApproxFunBaseTest as a dep

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,8 @@ using Test
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(ApproxFunSingularities, ambiguities=false)
+    Aqua.test_all(ApproxFunSingularities, ambiguities=false,
+        stale_deps=(; ignore=[:ApproxFunBaseTest]))
 end
 
 @testset "Sqrt" begin


### PR DESCRIPTION
This lets one carry out downstream tests in ApproxFunBaseTest by developing the package, without being flagged by Aqua.