### PR TITLE
improve inference in maxspace_rule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunSingularities"
 uuid = "f8fcb915-6b99-5be2-b79a-d6dbef8e6e7e"
-version = "0.3.11"
+version = "0.3.12"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/JacobiWeightOperators.jl
+++ b/src/JacobiWeightOperators.jl
@@ -251,7 +251,7 @@ for (OPrule,OP) in ((:maxspace_rule,:maxspace),(:union_rule,:union))
         function $OPrule(A::JacobiWeight, B::JacobiWeight)
             if domainscompatible(A,B) && isapproxinteger(A.β-B.β) && isapproxinteger(A.α-B.α)
                 ms=$OP(A.space,B.space)
-                if min(A.β,B.β)==0.0 && min(A.α,B.α) == 0.0
+                if min(A.β,B.β) == 0 && min(A.α,B.α) == 0
                     return ms
                 else
                     return JacobiWeight(min(A.β,B.β),min(A.α,B.α),ms)
@@ -259,7 +259,7 @@ for (OPrule,OP) in ((:maxspace_rule,:maxspace),(:union_rule,:union))
             end
             NoSpace()
         end
-        $OPrule(A::JacobiWeight, B::Space{<:IntervalOrSegmentDomain}) = $OPrule(A,JacobiWeight(0.,0.,B))
+        $OPrule(A::JacobiWeight, B::Space{<:IntervalOrSegmentDomain}) = $OPrule(A,JacobiWeight(0,0,B))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -193,6 +193,13 @@ end
         s = JacobiWeight(1, 1, us)
         @test order(s) == order(us)
     end
+
+    @testset "inference in maxspace" begin
+        sp = JacobiWeight(half(Odd(1)), half(Odd(1)), Legendre())
+        @test (@inferred maxspace(sp, sp)) == sp
+
+        @test (@inferred maxspace(sp, Legendre())) == ApproxFunBase.NoSpace()
+    end
 end
 
 @testset "Ray and Line" begin


### PR DESCRIPTION
Comparing against `Int` may rule out `Half{Odd{Int}}` types at compile time