### PR TITLE
Map to canonical in weighted space display

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunSingularities"
 uuid = "f8fcb915-6b99-5be2-b79a-d6dbef8e6e7e"
-version = "0.3.14"
+version = "0.3.15"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ApproxFunSingularitiesStaticArraysExt = "StaticArrays"
 
 [compat]
-ApproxFunBase = "0.8.36, 0.9"
+ApproxFunBase = "0.8.56, 0.9.12"
 ApproxFunBaseTest = "0.1"
 ApproxFunOrthogonalPolynomials = "0.2.3, 0.3, 0.4, 0.5, 0.6"
 Aqua = "0.6"

--- a/src/JacobiWeight.jl
+++ b/src/JacobiWeight.jl
@@ -509,16 +509,16 @@ end
 function show(io::IO,s::JacobiWeight)
     d=domain(s)
     #TODO: Get shift and weights right
+    sym = domain(s) == canonicaldomain(s) ? "x" : "𝑪($(domain(s)), x)"
     if s.α==s.β
-        print(io,"(1-x^2)^", s.α, "[")
+        print(io,"(1-$sym^2)^", s.α)
     elseif s.β==0
-        print(io,"(1-x)^", s.α, "[")
+        print(io,"(1-$sym)^", s.α)
     elseif s.α==0
-        print(io,"(1+x)^", s.β, "[")
+        print(io,"(1+$sym)^", s.β)
     else
-        print(io,"(1+x)^", s.β, "(1-x)^", s.α, "[")
+        print(io,"(1+$sym)^", s.β, " * (1-$sym)^", s.α)
     end
-
-    show(io,s.space)
-    print(io,"]")
+    print(io, " * ")
+    show(io, s.space)
 end

--- a/src/LogWeight.jl
+++ b/src/LogWeight.jl
@@ -99,12 +99,11 @@ end
 function show(io::IO,s::LogWeight)
     d=domain(s)
     #TODO: Get shift and weights right
+    sym = domain(s) == canonicaldomain(s) ? "x" : "𝑪($(domain(s)), x)"
     if s.α==s.β
-        print(io,"log((1-x^2)^", s.α, ")[")
+        print(io,"log((1-$sym^2)^", s.α, ")")
     else
-        print(io,"log((1+x)^", s.β, "(1-x)^", s.α, ")[")
+        print(io,"log((1+$sym)^", s.β, " * (1-$sym)^", s.α, ")")
     end
-
-    show(io,s.space)
-    print(io,"]")
+    print(io, " * ", s.space)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -853,37 +853,50 @@ end
         w = LogWeight(1.0, 0.0, Chebyshev())
         s = repr(w)
         @test startswith(s, "log")
-        @test contains(s, "Chebyshev")
+        @test contains(s, "Chebyshev()")
         @test contains(s, "(1+x)^1")
         @test contains(s, "(1-x)^0")
 
         w = LogWeight(1.0, 1.0, Chebyshev())
         s = repr(w)
         @test startswith(s, "log")
-        @test contains(s, "Chebyshev")
+        @test contains(s, "Chebyshev()")
         @test contains(s, "(1-x^2)^1")
+
+        w = LogWeight(1, 2, Chebyshev(0..1))
+        s = repr(w)
+        @test startswith(s, "log")
+        @test contains(s, "Chebyshev($(0..1))")
+        @test contains(s, "(1+𝑪($(0..1), x))^1")
+        @test contains(s, "(1-𝑪($(0..1), x))^2")
     end
     @testset "JacobiWeight" begin
         w = JacobiWeight(1.0, 0.0, Chebyshev())
         s = repr(w)
-        @test contains(s, "Chebyshev")
+        @test contains(s, "Chebyshev()")
         @test contains(s, "(1+x)^1")
 
         w = JacobiWeight(0.0, 1.0, Chebyshev())
         s = repr(w)
-        @test contains(s, "Chebyshev")
+        @test contains(s, "Chebyshev()")
         @test contains(s, "(1-x)^1")
 
         w = JacobiWeight(1.0, 1.0, Chebyshev())
         s = repr(w)
-        @test contains(s, "Chebyshev")
+        @test contains(s, "Chebyshev()")
         @test contains(s, "(1-x^2)^1")
 
         w = JacobiWeight(1.0, 2.0, Chebyshev())
         s = repr(w)
-        @test contains(s, "Chebyshev")
+        @test contains(s, "Chebyshev()")
         @test contains(s, "(1+x)^1")
         @test contains(s, "(1-x)^2")
+
+        w = JacobiWeight(1,2,Chebyshev(0..1))
+        s = repr(w)
+        @test contains(s, "Chebyshev($(0..1))")
+        @test contains(s, "(1+𝑪($(0..1), x))^1")
+        @test contains(s, "(1-𝑪($(0..1), x))^2")
     end
 end
 


### PR DESCRIPTION
After this,
```julia
julia> JacobiWeight(1,2,Chebyshev(0..0.5))
(1+𝑪(0.0 .. 0.5, x))^1 * (1-𝑪(0.0 .. 0.5, x))^2 * Chebyshev(0.0 .. 0.5)
```
where `𝑪(0 .. 1, x)` represents the map to the canonical space. This firstly makes it easier to see the zeros/poles of the weight (e.g. `(1-𝑪(0 ..  0.5, x))` has a zero at `x=0.5`), and secondly this makes it easy to copy-paste the weight to evaluate it:
```julia
julia> (x -> (1+𝑪(0.0 .. 0.5, x))^1 * (1-𝑪(0.0 .. 0.5, x))^2)(0.4)
0.2559999999999999
```

This doesn't display the map if the canonical domain is used:
```julia
julia> JacobiWeight(1,2,Chebyshev())
(1+x)^1 * (1-x)^2 * Chebyshev()
```