### PR TITLE
Improve type inference in JacobiWeight derivative

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunSingularities"
 uuid = "f8fcb915-6b99-5be2-b79a-d6dbef8e6e7e"
-version = "0.3.15"
+version = "0.3.16"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/JacobiWeightOperators.jl
+++ b/src/JacobiWeightOperators.jl
@@ -49,21 +49,22 @@ function differentiate(f::Fun{<:JacobiWeight{<:Any,<:IntervalOrSegment}})
     S=f.space
     d=domain(f)
     ff=Fun(S.space,f.coefficients)
+    zeroT = zero(S.α-1)
     if S.β==S.α==0
         u=differentiate(ff)
-        Fun(JacobiWeight(0,0,space(u)),u.coefficients)
+        Fun(JacobiWeight(zeroT,zeroT,space(u)),u.coefficients)
     elseif S.β==0
         x=Fun(identity,d)
         M=tocanonical(d,x)
         Mp=tocanonicalD(d,leftendpoint(d))
         u=-Mp*S.α*ff +(1-M).*differentiate(ff)
-        Fun(JacobiWeight(0,S.α-1,space(u)),u.coefficients)
+        Fun(JacobiWeight(zeroT,S.α-1,space(u)),u.coefficients)
     elseif S.α==0
         x=Fun(identity,d)
         M=tocanonical(d,x)
         Mp=tocanonicalD(d,leftendpoint(d))
         u=Mp*S.β*ff +(1+M).*differentiate(ff)
-        Fun(JacobiWeight(S.β-1,0,space(u)),u.coefficients)
+        Fun(JacobiWeight(S.β-1,zeroT,space(u)),u.coefficients)
     else
         x=Fun(identity,d)
         M=tocanonical(d,x)
@@ -158,26 +159,30 @@ end
 function jacobiweightDerivative(S::JacobiWeight{<:Any,<:ChebyshevInterval})
     d=domain(S)
 
-    if S.β==S.α==0
-        DerivativeWrapper(SpaceOperator(Derivative(S.space),S,
-                JacobiWeight(0,0,rangespace(Derivative(S.space)))),1)
-    elseif S.β==0
-        w=Fun(JacobiWeight(0,1,ConstantSpace(d)),[1.])
+    zeroT = zero(S.α-1)
+    oneT = oneunit(zeroT)
+    DSsp = Derivative(S.space)
 
-        DDβ0=-S.α + w*Derivative(S.space)
-        rsβ0=S.α==1 ? rangespace(DDβ0) : JacobiWeight(0.,S.α-1,rangespace(DDβ0))
+    if S.β==S.α==0
+        DerivativeWrapper(SpaceOperator(DSsp,S,
+                JacobiWeight(zeroT,zeroT,rangespace(DSsp))),1)
+    elseif S.β==0
+        w=Fun(JacobiWeight(zeroT,oneT,ConstantSpace(d)),[1.0])
+
+        DDβ0=-S.α + w*DSsp
+        rsβ0=S.α==1 ? rangespace(DDβ0) : JacobiWeight(zeroT,S.α-1,rangespace(DDβ0))
         DerivativeWrapper(SpaceOperator(DDβ0,S,rsβ0),1)
     elseif S.α==0
-        w=Fun(JacobiWeight(1,0,ConstantSpace(d)),[1.])
+        w=Fun(JacobiWeight(oneT,zeroT,ConstantSpace(d)),[1.0])
 
-        DDα0=S.β + w*Derivative(S.space)
-        rsα0=S.β==1 ? rangespace(DDα0) : JacobiWeight(S.β-1,0.,rangespace(DDα0))
+        DDα0=S.β + w*DSsp
+        rsα0=S.β==1 ? rangespace(DDα0) : JacobiWeight(S.β-1,zeroT,rangespace(DDα0))
         DerivativeWrapper(SpaceOperator(DDα0,S,rsα0),1)
     else
-        w=Fun(JacobiWeight(1,1,ConstantSpace(d)),[1.])
+        w=Fun(JacobiWeight(oneT,oneT,ConstantSpace(d)),[1.0])
         x=Fun()
 
-        DD=S.β*(1-x) - S.α*(1+x) + w*Derivative(S.space)
+        DD=S.β*(1-x) - S.α*(1+x) + w*DSsp
         rs=S.β==1 && S.α==1 ? rangespace(DD) : JacobiWeight(S.β-1,S.α-1,rangespace(DD))
         DerivativeWrapper(SpaceOperator(DD,S,rs),1)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,6 +132,12 @@ end
         @test (D*f)(x) ≈ exp(x)*(x-1)/(2x^2)
     end
 
+    @testset "differentiate" begin
+        f = Fun(x -> √(1-x^2) * x^2, JacobiWeight(0.5, 0.5, Chebyshev()))
+        g = @inferred ApproxFunSingularities.differentiate(f)
+        @test g ≈ Fun(x -> -x^3/√(1-x^2) + √(1-x^2) * 2x, JacobiWeight(-0.5, -0.5, Chebyshev()))
+    end
+
     @testset "Jacobi singularity" begin
         x = Fun(identity)
         f = exp(x)/(1-x.^2)


### PR DESCRIPTION
After this, `differentiate` is type-inferred for a `Fun` in a `JacobiWeight`-ed space:
```julia
julia> f = Fun(x -> √(1-x^2) * x^2, JacobiWeight(0.5, 0.5, Chebyshev()))
Fun((1-x^2)^0.5 * Chebyshev(), [0.5, 0.0, 0.5])

julia> g = @inferred ApproxFunSingularities.differentiate(f)
Fun((1-x^2)^-0.5 * Chebyshev(), [0.0, -0.25, 0.0, -0.75])
```